### PR TITLE
Parsing music file metadata and adding 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,8 @@
 		"react-hooks/rules-of-hooks": "error",
 		"react-hooks/exhaustive-deps": "warn",
 		"import/extensions": "off",
-		"prettier/prettier": "error"
+		"prettier/prettier": "error",
+		"no-unneeded-ternary": "off"
 	},
 	"settings": {
 		"import/resolver": {

--- a/db/migrations/1625013820569-CreateArtistSongJoinTable.js
+++ b/db/migrations/1625013820569-CreateArtistSongJoinTable.js
@@ -1,0 +1,40 @@
+const { Table } = require('typeorm');
+const { createForeignKeys, deleteForeignKeys } = require('../helpers/util');
+
+module.exports = class CreateArtistSongJoinTable1625013820569 {
+	async up(queryRunner) {
+		await queryRunner.createTable(
+			new Table({
+				name: 'artist_song',
+				columns: [
+					{
+						name: 'artistId',
+						type: 'integer',
+						isPrimary: true,
+					},
+					{
+						name: 'songId',
+						type: 'integer',
+						isPrimary: true,
+					},
+				],
+			})
+		);
+
+		await createForeignKeys(queryRunner, 'artist_song', [
+			{
+				column: 'artistId',
+				table: 'artist',
+			},
+			{
+				column: 'songId',
+				table: 'song',
+			},
+		]);
+	}
+
+	async down(queryRunner) {
+		await deleteForeignKeys(queryRunner, 'artist_song', ['artistId', 'songId']);
+		await queryRunner.dropTable('artist_song');
+	}
+};

--- a/electron/helpers/fs.ts
+++ b/electron/helpers/fs.ts
@@ -1,14 +1,15 @@
 import glob from 'glob-promise';
 
-export const getFilePaths = async (
+/**
+ * Recursively finds all files in a folder with provided extensions
+ */
+export const getFilesWithExt = async (
 	folderPath: string,
 	extensions: string[]
 ): Promise<string[]> => {
 	const extensionPattern = extensions.reduce((acc, cur) => {
 		return (acc += ',' + cur);
 	});
-	const filePaths = await glob(`${folderPath}/**/*.{${extensionPattern}}`);
 
-	console.log(filePaths);
-	return filePaths;
+	return await glob(`${folderPath}/**/*.{${extensionPattern}}`);
 };

--- a/electron/helpers/fs.ts
+++ b/electron/helpers/fs.ts
@@ -1,0 +1,14 @@
+import glob from 'glob-promise';
+
+export const getFilePaths = async (
+	folderPath: string,
+	extensions: string[]
+): Promise<string[]> => {
+	const extensionPattern = extensions.reduce((acc, cur) => {
+		return (acc += ',' + cur);
+	});
+	const filePaths = await glob(`${folderPath}/**/*.{${extensionPattern}}`);
+
+	console.log(filePaths);
+	return filePaths;
+};

--- a/electron/helpers/music.ts
+++ b/electron/helpers/music.ts
@@ -1,0 +1,31 @@
+import { parseFile } from 'music-metadata';
+import { getFilesWithExt } from './fs';
+
+// TODO: Have a seperate album artist and song artist
+export const getMusicMetadata = async (
+	filePath: string
+): Promise<{
+	title: string | undefined;
+	album: string | undefined;
+	albumArtist: string | undefined;
+	trackPosition: number | null;
+	data: string | undefined;
+}> => {
+	const metadata = await parseFile(filePath);
+
+	return {
+		title: metadata.common.title,
+		album: metadata.common.album,
+		albumArtist: metadata.common.artist,
+		trackPosition: metadata.common.track.no,
+		data: metadata.common.date,
+	};
+};
+
+export const parseMusicFiles = async (folderPath: string): Promise<void> => {
+	const musicFilePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
+
+	for (let i = 0; i < musicFilePaths.length; i++) {
+		console.log(await getMusicMetadata(musicFilePaths[i]));
+	}
+};

--- a/electron/helpers/music.ts
+++ b/electron/helpers/music.ts
@@ -6,7 +6,9 @@ import DatabaseManager from '#/loaders/db';
 import { Album } from '#/models/album.entity';
 import { Artist } from '#/models/artist.entity';
 import { Song } from '#/models/song.entity';
+
 import { ArtistRepository } from '#/repositories/artist.repository';
+import { AlbumRepository } from '#/repositories/album.repository';
 
 export interface ISongData {
 	title: string;
@@ -53,16 +55,64 @@ export const getSongMetadata = async (filePath: string): Promise<ISongData> => {
 
 export const parseMusicFiles = async (folderPath: string): Promise<void> => {
 	const connection = DatabaseManager.connection;
-	const albumRepository = connection.getRepository(Album);
+	const albumRepository = connection.getCustomRepository(AlbumRepository);
 	const artistRepository = connection.getCustomRepository(ArtistRepository);
 	const songRepository = connection.getRepository(Song);
 
-	// A local cache of all new and searched artists
-	const artistEntities: { [key: string]: Artist } = {};
+	const artistEntities: Artist[] = [];
+	const albumEntities: Album[] = [];
+	const songEntities: Song[] = [];
+
+	const artistEntitiesLookup: { [key: string]: number } = {};
+	const albumEntitiesLookup: { [key: string]: number } = {};
 
 	const filePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
 	const albumsData: { [key: string]: IAlbumData } = {};
 	const albumsDataKeys: string[] = [];
+
+	for (let i = 0; i < filePaths.length; i++) {
+		const filePath = filePaths[i];
+		const songData = await getSongMetadata(filePath);
+		songData.path = filePath;
+
+		const albumName = songData.albumName;
+		let albumIndex = albumEntitiesLookup[albumName];
+
+		if (albumIndex === undefined) {
+			// TODO Have proper checking if properties actually exist
+			// TODO Have proper album cover art path
+			const album = new Album();
+			album.name = albumName;
+			album.releaseDate = new Date(songData.albumReleaseDate);
+			album.coverImagePath = '';
+
+			albumIndex = albumEntities.length;
+			albumEntities.push(album);
+		}
+
+		// TODO Check if the song already exists
+		const song = new Song();
+		song.title = songData.title;
+		song.albumPosition = songData.trackPosition;
+		song.path = songData.path as string;
+		song.album = album;
+
+		const songIndex = songEntities.length;
+		songEntities.push(song);
+
+		if (albumName !== undefined) {
+			if (albumsData[albumName] !== undefined) {
+				albumsData[albumName].songs.push(songData);
+			} else {
+				albumsDataKeys.push(albumName);
+				albumsData[albumName] = {
+					artist: songData.albumArtist,
+					releaseDate: songData.albumReleaseDate,
+					songs: [songData],
+				};
+			}
+		}
+	}
 
 	for (let i = 0; i < filePaths.length; i++) {
 		const filePath = filePaths[i];
@@ -129,7 +179,7 @@ export const parseMusicFiles = async (folderPath: string): Promise<void> => {
 				let songArtistEntity = artistEntities[songArtistName];
 
 				if (songArtistEntity === undefined) {
-					songArtistEntity = await artistRepository.createWithData({
+					songArtistEntity = await artistRepository.appendOrCreate({
 						name: songArtistName,
 						songs: [song],
 					});
@@ -142,3 +192,95 @@ export const parseMusicFiles = async (folderPath: string): Promise<void> => {
 		}
 	}
 };
+
+// export const parseMusicFiles = async (folderPath: string): Promise<void> => {
+// 	const connection = DatabaseManager.connection;
+// 	const albumRepository = connection.getRepository(Album);
+// 	const artistRepository = connection.getCustomRepository(ArtistRepository);
+// 	const songRepository = connection.getRepository(Song);
+
+// 	// A local cache of all new and searched artists
+// 	const artistEntities: { [key: string]: Artist } = {};
+
+// 	const filePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
+// 	const albumsData: { [key: string]: IAlbumData } = {};
+// 	const albumsDataKeys: string[] = [];
+
+// 	for (let i = 0; i < filePaths.length; i++) {
+// 		const filePath = filePaths[i];
+// 		const songData = await getSongMetadata(filePath);
+// 		songData.path = filePath;
+
+// 		const albumName = songData.albumName;
+
+// 		if (albumName !== undefined) {
+// 			if (albumsData[albumName] !== undefined) {
+// 				albumsData[albumName].songs.push(songData);
+// 			} else {
+// 				albumsDataKeys.push(albumName);
+// 				albumsData[albumName] = {
+// 					artist: songData.albumArtist,
+// 					releaseDate: songData.albumReleaseDate,
+// 					songs: [songData],
+// 				};
+// 			}
+// 		}
+// 	}
+
+// 	for (let i = 0; i < albumsDataKeys.length; i++) {
+// 		const albumName = albumsDataKeys[i];
+// 		const albumData = albumsData[albumName];
+// 		let albumArtistEntity: Artist | undefined = artistEntities[albumData.artist];
+
+// 		// TODO Have proper checking if properties actually exist
+// 		// TODO Have proper album cover art path
+// 		const album = new Album();
+// 		album.name = albumName;
+// 		album.releaseDate = new Date(albumData.releaseDate);
+// 		album.coverImagePath = '';
+// 		await albumRepository.save(album);
+
+// 		/** Insert album artist */
+// 		if (albumArtistEntity === undefined) {
+// 			albumArtistEntity = await artistRepository.appendOrCreate({
+// 				name: albumData.artist,
+// 				albums: [album],
+// 			});
+// 		} else {
+// 			albumArtistEntity = await artistRepository.addAlbum(albumArtistEntity, album);
+// 		}
+
+// 		artistEntities[albumData.artist] = albumArtistEntity;
+
+// 		for (let j = 0; j < albumData.songs.length; j++) {
+// 			const songData = albumData.songs[j];
+// 			console.log(colors.red(songData.title));
+// 			console.log(colors.blue(songData.songArtists.join(', ')));
+
+// 			// TODO Check if the song already exists
+// 			const song = new Song();
+// 			song.title = songData.title;
+// 			song.albumPosition = songData.trackPosition;
+// 			song.path = songData.path as string;
+// 			song.album = album;
+// 			await songRepository.save(song);
+
+// 			for (let k = 0; k < songData.songArtists.length; k++) {
+// 				const songArtistName = songData.songArtists[k];
+// 				console.log(colors.green(songArtistName));
+// 				let songArtistEntity = artistEntities[songArtistName];
+
+// 				if (songArtistEntity === undefined) {
+// 					songArtistEntity = await artistRepository.appendOrCreate({
+// 						name: songArtistName,
+// 						songs: [song],
+// 					});
+// 				} else {
+// 					songArtistEntity = await artistRepository.addSong(songArtistEntity, song);
+// 				}
+
+// 				artistEntities[songArtistName] = songArtistEntity;
+// 			}
+// 		}
+// 	}
+// };

--- a/electron/helpers/music.ts
+++ b/electron/helpers/music.ts
@@ -1,42 +1,82 @@
 import { parseFile } from 'music-metadata';
 import { getFilesWithExt } from './fs';
 
-export interface IMusicData {
+import DatabaseManager from '#/loaders/db';
+import { Album } from '#/models/album.entity';
+import { Artist } from '#/models/artist.entity';
+import { Song } from '#/models/song.entity';
+
+export interface ISongData {
 	title: string | undefined;
-	album: string | undefined;
+	albumName: string | undefined;
 	albumArtist: string | undefined;
+	albumReleaseDate: string | undefined;
 	trackPosition: number | null;
-	data: string | undefined;
+	date: string | undefined;
+	path?: string;
+}
+
+export interface IAlbumData {
+	artist: string | undefined;
+	releaseDate: string | undefined;
+	songs: ISongData[];
 }
 
 // TODO: Have a seperate album artist and song artist
-export const getMusicMetadata = async (filePath: string): Promise<IMusicData> => {
+export const getSongMetadata = async (filePath: string): Promise<ISongData> => {
 	const metadata = await parseFile(filePath);
 
 	return {
 		title: metadata.common.title,
-		album: metadata.common.album,
-		albumArtist: metadata.common.artist,
+		albumName: metadata.common.album,
+		albumArtist: metadata.common.albumartist,
+		albumReleaseDate: metadata.common.date,
 		trackPosition: metadata.common.track.no,
-		data: metadata.common.date,
+		date: metadata.common.date,
 	};
 };
 
 export const parseMusicFiles = async (folderPath: string): Promise<void> => {
-	const musicFilePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
-	const musicFilesData: { [key: string]: IMusicData[] } = {};
+	const connection = DatabaseManager.connection;
+	const albumRepository = connection.getRepository(Album);
+	const artistRepository = connection.getRepository(Artist);
+	const songRepository = connection.getRepository(Song);
 
-	for (let i = 0; i < musicFilePaths.length; i++) {
-		const data = await getMusicMetadata(musicFilePaths[i]);
+	const filePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
+	const albumsData: { [key: string]: IAlbumData } = {};
+	const albumsDataKeys: string[] = [];
 
-		if (data.album !== undefined) {
-			if (musicFilesData[data.album] !== undefined) {
-				musicFilesData[data.album].push(data);
+	for (let i = 0; i < filePaths.length; i++) {
+		const filePath = filePaths[i];
+		const songData = await getSongMetadata(filePath);
+		songData.path = filePath;
+
+		const albumName = songData.albumName;
+
+		if (albumName !== undefined) {
+			if (albumsData[albumName] !== undefined) {
+				albumsData[albumName].songs.push(songData);
 			} else {
-				musicFilesData[data.album] = [data];
+				albumsDataKeys.push(albumName);
+				albumsData[albumName] = {
+					artist: songData.albumArtist,
+					releaseDate: songData.albumReleaseDate,
+					songs: [songData],
+				};
 			}
 		}
 	}
 
-	console.log(musicFilesData);
+	for (let i = 0; i < albumsDataKeys.length; i++) {
+		const albumName = albumsDataKeys[i];
+		const albumData = albumsData[albumName];
+
+		// TODO Have proper checking if properties actually exist
+		// TODO Have proper album cover art path
+		const album = new Album();
+		album.name = albumName;
+		album.releaseDate = new Date(albumData.releaseDate as string);
+		album.coverImagePath = '';
+		await albumRepository.save(album);
+	}
 };

--- a/electron/helpers/music.ts
+++ b/electron/helpers/music.ts
@@ -1,16 +1,16 @@
 import { parseFile } from 'music-metadata';
 import { getFilesWithExt } from './fs';
 
-// TODO: Have a seperate album artist and song artist
-export const getMusicMetadata = async (
-	filePath: string
-): Promise<{
+export interface IMusicData {
 	title: string | undefined;
 	album: string | undefined;
 	albumArtist: string | undefined;
 	trackPosition: number | null;
 	data: string | undefined;
-}> => {
+}
+
+// TODO: Have a seperate album artist and song artist
+export const getMusicMetadata = async (filePath: string): Promise<IMusicData> => {
 	const metadata = await parseFile(filePath);
 
 	return {
@@ -24,8 +24,19 @@ export const getMusicMetadata = async (
 
 export const parseMusicFiles = async (folderPath: string): Promise<void> => {
 	const musicFilePaths = await getFilesWithExt(folderPath, ['mp3', 'wav', 'flac']);
+	const musicFilesData: { [key: string]: IMusicData[] } = {};
 
 	for (let i = 0; i < musicFilePaths.length; i++) {
-		console.log(await getMusicMetadata(musicFilePaths[i]));
+		const data = await getMusicMetadata(musicFilePaths[i]);
+
+		if (data.album !== undefined) {
+			if (musicFilesData[data.album] !== undefined) {
+				musicFilesData[data.album].push(data);
+			} else {
+				musicFilesData[data.album] = [data];
+			}
+		}
 	}
+
+	console.log(musicFilesData);
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, dialog } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import installExtension, {
@@ -7,18 +7,18 @@ import installExtension, {
 } from 'electron-devtools-installer';
 import 'reflect-metadata';
 import DatabaseManager from '#/loaders/db';
-
-import TestRun from './test';
+import { getFilePaths } from './helpers/fs';
 
 let mainWindow: Electron.BrowserWindow | null;
 
-function createWindow() {
+async function createWindow() {
 	mainWindow = new BrowserWindow({
 		width: 1280,
 		height: 720,
 		backgroundColor: '#121212',
 		webPreferences: {
 			nodeIntegration: true,
+			enableRemoteModule: true,
 		},
 	});
 
@@ -37,6 +37,12 @@ function createWindow() {
 	mainWindow.on('closed', () => {
 		mainWindow = null;
 	});
+
+	const paths = await dialog.showOpenDialog(mainWindow, {
+		properties: ['openDirectory'],
+	});
+
+	await getFilePaths(paths.filePaths[0], ['mp3', 'wav', 'flac']);
 }
 
 app
@@ -53,7 +59,5 @@ app
 		}
 
 		await DatabaseManager.init();
-
-		await TestRun();
 	});
 app.allowRendererProcessReuse = true;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,7 +7,8 @@ import installExtension, {
 } from 'electron-devtools-installer';
 import 'reflect-metadata';
 import DatabaseManager from '#/loaders/db';
-import { getFilePaths } from './helpers/fs';
+import { getFilesWithExt } from './helpers/fs';
+import { parseMusicFiles } from './helpers/music';
 
 let mainWindow: Electron.BrowserWindow | null;
 
@@ -42,7 +43,9 @@ async function createWindow() {
 		properties: ['openDirectory'],
 	});
 
-	await getFilePaths(paths.filePaths[0], ['mp3', 'wav', 'flac']);
+	if (!paths.canceled) {
+		await parseMusicFiles(paths.filePaths[0]);
+	}
 }
 
 app

--- a/electron/models/artist.entity.ts
+++ b/electron/models/artist.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, JoinTable, ManyToMany } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { Album } from './album.entity';
+import { Song } from './song.entity';
 
 @Entity()
 export class Artist extends BaseEntity {
@@ -10,4 +11,8 @@ export class Artist extends BaseEntity {
 	@ManyToMany(() => Album, (album) => album.artists)
 	@JoinTable({ name: 'artist_album' })
 	albums: Album[];
+
+	@ManyToMany(() => Song, (song) => song.artists)
+	@JoinTable({ name: 'artist_song' })
+	songs: Song[];
 }

--- a/electron/models/artist.entity.ts
+++ b/electron/models/artist.entity.ts
@@ -8,11 +8,11 @@ export class Artist extends BaseEntity {
 	@Column({ type: 'varchar' })
 	name: string;
 
-	@ManyToMany(() => Album, (album) => album.artists)
+	@ManyToMany(() => Album, (album) => album.artists, { cascade: ['insert', 'remove'] })
 	@JoinTable({ name: 'artist_album' })
 	albums: Album[];
 
-	@ManyToMany(() => Song, (song) => song.artists)
+	@ManyToMany(() => Song, (song) => song.artists, { cascade: ['insert', 'remove'] })
 	@JoinTable({ name: 'artist_song' })
 	songs: Song[];
 }

--- a/electron/models/song.entity.ts
+++ b/electron/models/song.entity.ts
@@ -7,7 +7,7 @@ export class Song extends BaseEntity {
 	@Column({ type: 'varchar' })
 	title: string;
 
-	@Column()
+	@Column({ type: 'integer' })
 	albumPosition: number;
 
 	@Column({ type: 'text' })

--- a/electron/models/song.entity.ts
+++ b/electron/models/song.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToMany, ManyToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { Album } from './album.entity';
+import { Artist } from './artist.entity';
 
 @Entity()
 export class Song extends BaseEntity {
@@ -15,4 +16,7 @@ export class Song extends BaseEntity {
 
 	@ManyToOne(() => Album, (album) => album.songs)
 	album: Album;
+
+	@ManyToMany(() => Artist, (artist) => artist.songs)
+	artists: Artist[];
 }

--- a/electron/repositories/album.repository.ts
+++ b/electron/repositories/album.repository.ts
@@ -16,7 +16,7 @@ export class AlbumRepository extends Repository<Album> {
 	/**
 	 * Inserts album data into the database
 	 */
-	createWithData({
+	saveWithData({
 		name,
 		releaseDate,
 		coverImagePath,
@@ -30,6 +30,26 @@ export class AlbumRepository extends Repository<Album> {
 		album.songs = songs ? songs : [];
 		album.artists = artists ? artists : [];
 		return this.save(album);
+	}
+
+	/**
+	 * Creates an album object
+	 * Does not insert into the database
+	 */
+	createWithData({
+		name,
+		releaseDate,
+		coverImagePath,
+		songs,
+		artists,
+	}: IAlbumData): Album {
+		const album = new Album();
+		album.name = name;
+		album.releaseDate = releaseDate;
+		album.coverImagePath = coverImagePath;
+		album.songs = songs ? songs : [];
+		album.artists = artists ? artists : [];
+		return album;
 	}
 
 	/**

--- a/electron/repositories/album.repository.ts
+++ b/electron/repositories/album.repository.ts
@@ -1,0 +1,41 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { Artist } from '#/models/artist.entity';
+import { Album } from '#/models/album.entity';
+import { Song } from '#/models/song.entity';
+
+export interface IAlbumData {
+	name: string;
+	releaseDate: Date;
+	coverImagePath: string;
+	songs?: Song[];
+	artists?: Artist[];
+}
+
+@EntityRepository(Album)
+export class AlbumRepository extends Repository<Album> {
+	/**
+	 * Inserts album data into the database
+	 */
+	createWithData({
+		name,
+		releaseDate,
+		coverImagePath,
+		songs,
+		artists,
+	}: IAlbumData): Promise<Album> {
+		const album = new Album();
+		album.name = name;
+		album.releaseDate = releaseDate;
+		album.coverImagePath = coverImagePath;
+		album.songs = songs ? songs : [];
+		album.artists = artists ? artists : [];
+		return this.save(album);
+	}
+
+	/**
+	 * Finds an album that matches a given name and date
+	 */
+	findBy(name: string, releaseDate: Date): Promise<Album | undefined> {
+		return this.findOne({ where: { name, releaseDate } });
+	}
+}

--- a/electron/repositories/artist.repository.ts
+++ b/electron/repositories/artist.repository.ts
@@ -14,7 +14,7 @@ export class ArtistRepository extends Repository<Artist> {
 	/**
 	 * Inserts artist data into the database
 	 */
-	createWithData({ name, albums, songs }: IArtistData): Promise<Artist> {
+	saveWithData({ name, albums, songs }: IArtistData): Promise<Artist> {
 		const artist = new Artist();
 		artist.name = name;
 		artist.albums = albums ? albums : [];
@@ -23,9 +23,21 @@ export class ArtistRepository extends Repository<Artist> {
 	}
 
 	/**
+	 * Creates an artist object
+	 * Does not save into the database
+	 */
+	createWithData({ name, albums, songs }: IArtistData): Artist {
+		const artist = new Artist();
+		artist.name = name;
+		artist.albums = albums ? albums : [];
+		artist.songs = songs ? songs : [];
+		return artist;
+	}
+
+	/**
 	 * Finds an artist that matches a given name
 	 */
-	findByName(name: string): Promise<Artist | undefined> {
+	findBy(name: string): Promise<Artist | undefined> {
 		return this.findOne({ where: { name } });
 	}
 
@@ -37,9 +49,9 @@ export class ArtistRepository extends Repository<Artist> {
 		if (albums === undefined) albums = [];
 		if (songs === undefined) songs = [];
 
-		const artist = await this.findByName(name);
+		const artist = await this.findBy(name);
 
-		if (artist === undefined) return this.createWithData({ name, albums, songs });
+		if (artist === undefined) return this.saveWithData({ name, albums, songs });
 		else return this.addData(artist, albums, songs);
 	}
 

--- a/electron/repositories/artist.repository.ts
+++ b/electron/repositories/artist.repository.ts
@@ -1,0 +1,71 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { Artist } from '#/models/artist.entity';
+import { Album } from '#/models/album.entity';
+import { Song } from '#/models/song.entity';
+
+export interface IArtistData {
+	name: string;
+	albums?: Album[];
+	songs?: Song[];
+}
+
+@EntityRepository(Artist)
+export class ArtistRepository extends Repository<Artist> {
+	/**
+	 * Inserts artist data into the database
+	 */
+	createWithData({ name, albums, songs }: IArtistData): Promise<Artist> {
+		const artist = new Artist();
+		artist.name = name;
+		artist.albums = albums ? albums : [];
+		artist.songs = songs ? songs : [];
+		return this.save(artist);
+	}
+
+	/**
+	 * Finds an artist that matches a given name
+	 */
+	findByName(name: string): Promise<Artist | undefined> {
+		return this.findOne({ where: { name } });
+	}
+
+	/**
+	 * Finds an artist by their name and appends provided data
+	 * If the artist does not exist in the databse then inserts with provided data
+	 */
+	async appendOrCreate({ name, albums, songs }: IArtistData): Promise<Artist> {
+		if (albums === undefined) albums = [];
+		if (songs === undefined) songs = [];
+
+		const artist = await this.findByName(name);
+
+		if (artist === undefined) return this.createWithData({ name, albums, songs });
+		else return this.addData(artist, albums, songs);
+	}
+
+	addAlbum(artist: Artist, album: Album): Promise<Artist> {
+		artist.albums.push(album);
+		return this.save(artist);
+	}
+
+	addAlbums(artist: Artist, albums: Album[]): Promise<Artist> {
+		artist.albums.push(...albums);
+		return this.save(artist);
+	}
+
+	addSong(artist: Artist, song: Song): Promise<Artist> {
+		artist.songs.push(song);
+		return this.save(artist);
+	}
+
+	addSongs(artist: Artist, songs: Song[]): Promise<Artist> {
+		artist.songs.push(...songs);
+		return this.save(artist);
+	}
+
+	addData(artist: Artist, albums: Album[], songs: Song[]): Promise<Artist> {
+		artist.albums.push(...albums);
+		artist.songs.push(...songs);
+		return this.save(artist);
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,19 @@
 						"@babel/helper-validator-identifier": "^7.14.5",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				},
 				"@babel/parser": {
@@ -506,6 +519,18 @@
 				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/parser": {
@@ -666,6 +691,19 @@
 						"@babel/helper-validator-identifier": "^7.14.5",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				},
 				"@babel/parser": {
@@ -857,6 +895,19 @@
 						"@babel/helper-validator-identifier": "^7.14.5",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				},
 				"@babel/parser": {
@@ -6103,16 +6154,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
 		"char-regex": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -6615,10 +6656,9 @@
 			"dev": true
 		},
 		"colors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-			"dev": true
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -7332,6 +7372,19 @@
 				"lodash.map": "^4.5.1",
 				"longest": "^2.0.1",
 				"word-wrap": "^1.0.3"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"dargs": {
@@ -7641,6 +7694,12 @@
 				"minimatch": "3.0.4"
 			},
 			"dependencies": {
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+					"dev": true
+				},
 				"commander": {
 					"version": "2.9.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -11452,6 +11511,19 @@
 				"string-width": "^2.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"internal-ip": {
@@ -12034,6 +12106,17 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
 					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
 					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
 				}
 			}
 		},
@@ -15962,6 +16045,17 @@
 				"string.prototype.padend": "^3.0.0"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -21183,6 +21277,28 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
 				},
 				"cliui": {
 					"version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3781,8 +3781,7 @@
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/minimist": {
 			"version": "1.2.1",
@@ -3793,8 +3792,7 @@
 		"@types/node": {
 			"version": "15.12.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-			"integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
-			"dev": true
+			"integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -10642,6 +10640,25 @@
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
+			}
+		},
+		"glob-promise": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.0.tgz",
+			"integrity": "sha512-XQlQamNoMi++Sd5c8Y3l/FE2aqia+Lo1ghXEJZiqXdOvWOosA/zVetMahrdfRwwPjCXcFjg3fUogryAMa7IRQQ==",
+			"requires": {
+				"@types/glob": "^7.1.3"
+			},
+			"dependencies": {
+				"@types/glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+					"requires": {
+						"@types/minimatch": "*",
+						"@types/node": "*"
+					}
+				}
 			}
 		},
 		"global-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3590,6 +3590,11 @@
 				"@testing-library/dom": "^7.17.1"
 			}
 		},
+		"@tokenizer/token": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+			"integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+		},
 		"@tsconfig/node10": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -3672,8 +3677,7 @@
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
-			"dev": true
+			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
 		},
 		"@types/electron-devtools-installer": {
 			"version": "2.2.0",
@@ -3855,6 +3859,15 @@
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
+			}
+		},
+		"@types/readable-stream": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.10.tgz",
+			"integrity": "sha512-xwSXvAv9x4B9Vj88AMZnFyEVLilz1EBxKvRUhGqIF4nJpRQBSTm7jS236X4Y9Y2qPsVvaMxwrGJlNhLHEahlFQ==",
+			"requires": {
+				"@types/node": "*",
+				"safe-buffer": "*"
 			}
 		},
 		"@types/source-list-map": {
@@ -6828,8 +6841,7 @@
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"conventional-changelog-angular": {
 			"version": "5.0.12",
@@ -9896,6 +9908,16 @@
 						"ajv-keywords": "^3.5.2"
 					}
 				}
+			}
+		},
+		"file-type": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.0.tgz",
+			"integrity": "sha512-OxgWA9tbL8N/WP00GD1z8O0MiwQKFyWRs1q+3FhjdvcGgKqwxcejyGWso3n4/IMU6DdwV+ARZ4A7TTnPkDcSiw==",
+			"requires": {
+				"readable-web-to-node-stream": "^3.0.0",
+				"strtok3": "^6.0.3",
+				"token-types": "^2.0.0"
 			}
 		},
 		"filelist": {
@@ -15551,6 +15573,34 @@
 			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
 			"dev": true
 		},
+		"music-metadata": {
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.8.8.tgz",
+			"integrity": "sha512-NUtXW6FQA1fvBp4Q5o78Df6LHWqyny8bHxArJ79i5lr2N28jEd9HYyH09CAHKLjwiv58QLRa8r3P5nX36Spcxw==",
+			"requires": {
+				"content-type": "^1.0.4",
+				"debug": "^4.3.1",
+				"file-type": "^16.5.0",
+				"media-typer": "^1.1.0",
+				"strtok3": "^6.0.8",
+				"token-types": "^2.1.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"media-typer": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+					"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+				}
+			}
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -16514,6 +16564,11 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"peek-readable": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
+			"integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg=="
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -17565,6 +17620,27 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"readable-web-to-node-stream": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz",
+			"integrity": "sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==",
+			"requires": {
+				"@types/readable-stream": "^2.3.9",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -19094,6 +19170,16 @@
 			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
 			"dev": true
 		},
+		"strtok3": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.8.tgz",
+			"integrity": "sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==",
+			"requires": {
+				"@tokenizer/token": "^0.1.1",
+				"@types/debug": "^4.1.5",
+				"peek-readable": "^3.1.3"
+			}
+		},
 		"style-loader": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
@@ -19856,6 +19942,22 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
+		},
+		"token-types": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
+			"integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+			"requires": {
+				"@tokenizer/token": "^0.1.1",
+				"ieee754": "^1.2.1"
+			},
+			"dependencies": {
+				"ieee754": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+				}
+			}
 		},
 		"tough-cookie": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.14.6",
 		"app-root-path": "^3.0.0",
+		"glob-promise": "^4.2.0",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
 		"typeorm:migrate": "typeorm migration:run",
 		"typeorm:revert": "typeorm migration:revert",
-		"typeorm:reset": "typeorm schema:drop"
+		"typeorm:drop": "typeorm schema:drop",
+		"typeorm:reset": "npm-run-all typeorm:drop typeorm:migrate"
 	},
 	"keywords": [],
 	"author": "Diego Fernandes <diego.schell.f@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.14.6",
 		"app-root-path": "^3.0.0",
+		"colors": "^1.4.0",
 		"glob-promise": "^4.2.0",
 		"music-metadata": "^7.8.8",
 		"react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"@babel/runtime": "^7.14.6",
 		"app-root-path": "^3.0.0",
 		"glob-promise": "^4.2.0",
+		"music-metadata": "^7.8.8",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"react-router-dom": "^5.2.0",


### PR DESCRIPTION
This PR adds MusicMetadata to parse the metadata stored in music files. This metadata is parsed internally and put into TypeORM objects to be inserted into the database. More cleanup of the code is required with better checking of edge cases. 

To achieve this, we needed to:

- Use filesystem bindings provided by Node.js to recursively find file paths of all music files in the selected directory
- Parse metadata with an external library (MusicMetadata)
- Organise the song metadata in a structure that would make it very efficient to perform bulk insertions into the database
- Create custom TypeORM repositories for entity tables so custom functions can be added to perform more advanced operations with TypeORM objects